### PR TITLE
feature/array exercises and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then run the following command:
 
 This folder contains a Gemfile, which tells bundle which gems to install locally and makes them available for use in that directory. In this case, we are installing RSpec, which is a popular Ruby testing framework.
 
-Verify that the installation was succesful by simply running the following command:
+Verify that the installation was successful by simply running the following command:
 
     rspec
 

--- a/ruby_basics/6_arrays/.rspec
+++ b/ruby_basics/6_arrays/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/ruby_basics/6_arrays/exercises/array_exercises.rb
+++ b/ruby_basics/6_arrays/exercises/array_exercises.rb
@@ -1,0 +1,65 @@
+def nil_array(number)
+  # return an array containing the number of nil values
+end
+
+def nested_array(number)
+  # return an array containing the number of empty arrays
+end
+
+def first_index(array)
+  # return the first index of the array
+end
+
+def last_three_elements(array)
+  # return the last 3 elements of the array
+end
+
+def second_index(array)
+  # return the second index of the array
+end
+
+def add_element(array)
+  # add an element (of any value) to the array
+end
+
+def remove_last_element(array)
+  # Step 1: remove the last element from the array
+
+  # Step 2: return the array (because Step 1 returns the value of the element removed)
+  array
+end
+
+def remove_first_three_elements(array)
+  # Step 1: remove the first three elements
+
+  # Step 2: return the array (because Step 1 returns the values of the elements removed)
+  array
+end
+
+def array_concatenation(original, additional)
+  # return an array adding the original and additional array together
+end
+
+def array_difference(original, comparison)
+  # return an array of elements from the original array that are not in the comparison array
+end
+
+def empty_array?(array)
+  # return true if the array is empty
+end
+
+def reverse(array)
+  # return the reverse of the array
+end
+
+def array_length(array)
+  # return the length of the array
+end
+
+def include?(array, value)
+  # return true if the array includes the value
+end
+
+def join(array, separator)
+  # return the result of joining the array with the separator
+end

--- a/ruby_basics/6_arrays/spec/array_exercises_spec.rb
+++ b/ruby_basics/6_arrays/spec/array_exercises_spec.rb
@@ -1,0 +1,172 @@
+require 'spec_helper'
+require_relative '../exercises/array_exercises'
+
+RSpec.describe 'Array Exercises' do
+  describe 'nil array exercise' do
+
+    it 'returns an array containing 5 nil values' do
+      expect(nil_array(5)).to eq([nil, nil, nil, nil, nil])
+    end
+
+    # remove the 'x' from the line below to unskip the test
+    xit 'returns an array containing 2 nil values' do
+      expect(nil_array(2)).to eq([nil, nil])
+    end
+  end
+
+  describe 'nested array exercise' do
+    
+    xit 'returns a nested array with 4 empty arrays' do
+      expect(nested_array(4)).to eq([[], [], [], []])
+    end
+    
+    xit 'returns a nested array with 3 empty arrays' do
+      expect(nested_array(3)).to eq([[], [], []])
+    end
+  end
+
+  describe 'first index exercise' do
+
+    xit 'returns the first index of an array of numbers' do
+      expect(first_index([2, 4, 6, 8, 10])).to eq(2)
+    end
+
+    xit 'returns the first index of an array of strings' do
+      expect(first_index(['foo', 'bar'])).to eq('foo')
+    end
+  end
+
+  describe 'last three elements exercise' do
+
+    xit 'returns an array of the last three elements' do
+      expect(last_three_elements([2, 4, 6, 8, 10])).to eq([6, 8, 10])
+    end
+
+    xit 'returns all of the elements when there are less than 3 elements' do
+      expect(last_three_elements(['foo', 'bar'])).to eq(['foo', 'bar'])
+    end
+  end
+
+  describe 'second index exercise' do
+
+    xit 'returns the second index of an array' do
+      expect(second_index([2, 4, 6, 8, 10])).to eq(6)
+    end
+
+    xit 'returns nil if the array does not have a second index' do
+      expect(second_index(['foo', 'bar'])).to eq(nil)
+    end
+  end
+
+  describe 'add element exercise' do
+
+    xit 'increases the length of an array by 1' do
+      numbers = [1, 2, 3, 4]
+      expect { add_element(numbers) }.to change { numbers.length }.by(1)
+    end
+
+    xit 'increases the length of an empty array by 1' do
+      data = []
+      expect { add_element(data) }.to change { data.length }.by(1)
+    end
+  end
+
+  describe 'remove last element exercise' do
+
+    xit 'returns the array without the last element' do
+      expect(remove_last_element([1, 3, 5])).to eq([1, 3])
+    end
+
+    xit 'returns an empty array when the array only has one element' do
+      expect(remove_last_element(['foo'])).to eq([])
+    end
+  end
+
+  describe 'remove first three elements exercise' do
+
+    xit 'returns the array without the first three elements' do
+      expect(remove_first_three_elements([1, 3, 5, 7, 9])).to eq([7, 9])
+    end
+
+    xit 'returns an empty array when the array has less than 3 elements' do
+      expect(remove_first_three_elements(['foo', 'bar'])).to eq([])
+    end
+  end
+
+  describe 'array concatenation exercise' do
+
+    xit 'returns an array adding two arrays of numbers together' do
+      expect(array_concatenation([1, 3, 5], [2, 4, 6])).to eq([1, 3, 5, 2, 4, 6])
+    end
+
+    xit 'returns an array adding arrays of strings and numbers together' do
+      expect(array_concatenation(['a', 'b', 'c'], [1, 2, 3])).to eq(['a', 'b', 'c', 1, 2, 3])
+    end
+  end
+
+  describe 'array difference exercise' do
+
+    xit 'returns an array subtracting two arrays of numbers' do
+      expect(array_difference([0, 1, 1, 2, 3, 5], [0, 1, 2])).to eq([3, 5])
+    end
+
+    xit 'returns an array subtracting two arrays of strings' do
+      expect(array_difference(['foo', 'bar', 'baz'], ['bar','hello'])).to eq(['foo', 'baz'])
+    end
+  end
+
+  describe 'empty array exercise' do
+
+    xit 'returns true when the array is empty' do
+      expect(empty_array?([])).to be true
+    end
+
+    xit 'returns false when the array is not empty' do
+      expect(empty_array?([1, 2, 3])).to be false
+    end
+  end
+
+  describe 'reverse exercise' do
+
+    xit 'returns an array containing the elements in reverse order' do
+      expect(reverse([0, 1, 1, 2, 3, 5])).to eq([5, 3, 2, 1, 1, 0])
+    end
+
+    xit 'returns an array containing the element when there is only one' do
+      expect(reverse(['foo'])).to eq(['foo'])
+    end
+  end
+
+  describe 'array length exercise' do
+
+    xit 'returns the length of the array' do
+      expect(array_length([0, 1, 1, 2, 3, 5])).to eq(6)
+    end
+
+    xit 'returns zero when the array is empty' do
+      expect(array_length([])).to eq(0)
+    end
+  end
+
+  describe 'include exercise' do
+
+    xit 'returns true when the array contains the specified value' do
+      expect(include?([0, 1, 1, 2, 3, 5], 3)).to be true
+    end
+
+    xit 'returns false when the array does not contain the specified value' do
+      expect(include?([0, 1, 1, 2, 3, 5], 8)).to be false
+    end
+  end
+
+  describe 'join exercise' do
+
+    xit 'returns a string joining an array of numbers with " + "' do
+      expect(join([0, 1, 1, 2, 3, 5], ' + ')).to eq('0 + 1 + 1 + 2 + 3 + 5')
+    end
+
+    xit 'returns a string joining an array of strings with " "' do
+      expect(join(['foo', 'bar', 'baz'], ' ')).to eq('foo bar baz')
+    end
+  end
+end

--- a/ruby_basics/6_arrays/spec/spec_helper.rb
+++ b/ruby_basics/6_arrays/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/ruby_basics/README.md
+++ b/ruby_basics/README.md
@@ -5,7 +5,7 @@ These exercises are designed to compliment the [Ruby Basic lessons](https://www.
 
 1. First change directory into the lesson directory, for example `cd 1_data_types`
 2. Run the tests for an exercise file, for example `rspec spec/numbers_exercises_spec.rb`. The first test will fail and the rest will be skipped.
-3. Open that coresponding exercise file in your text editor, in this case the `exercises/numbers_exercises.rb` file
+3. Open that corresponding exercise file in your text editor, in this case the `exercises/numbers_exercises.rb` file
 4. Write the code to get the failing test to pass in the exercise file and run the tests again to verify it passes.
 5. Go into the test file and unskip the next test by removing the `x` from `xit`.
 6. Run your tests again `rspec spec/numbers_exercises_spec.rb` the second test should now be failing.
@@ -17,3 +17,7 @@ These exercises are designed to compliment the [Ruby Basic lessons](https://www.
 
 - [ ] Numbers Exercises 
 - [ ] Strings Exercises 
+
+#### 6.Arrays
+
+- [ ] Array Exercises 


### PR DESCRIPTION
There is an array exercise and 2 tests for each example the lesson/issue covers. Instead of using `a` and `b` or `array1` and `array2` for a few of the examples, I decided to get a little more creative for the argument names.

In addition, I saw two small typos in the README files, so I went ahead and fixed them.

Closes issue #10 