### PR TITLE
Add feature: basic enumerable

### DIFF
--- a/ruby_basics/9_basic_enumerables/.rspec
+++ b/ruby_basics/9_basic_enumerables/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -1,0 +1,19 @@
+def current_inventory(list)
+  list.each { |key, value| puts "#{key}: #{value}" } 
+end
+
+def index_method(array)
+  array.each_with_index do |item, index|
+    puts item if index % 3 == 0
+  end
+end
+
+def map_method(array)
+  array.map do |item|
+    item.downcase.reverse.capitalize
+  end
+end
+
+def low_inventory(list)
+  list.select { |key, value| value < 4 } 
+end

--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -1,28 +1,22 @@
 def display_current_inventory(inventory_list)
   # use #each to iterate through each item of the inventory_list (a hash)
-  # using puts, output each list item "<key>, quantity: <value>" to console
-  inventory_list.each { |key, value| puts "#{key}, quantity: #{value}" } 
+  # use puts to output each list item "<key>, quantity: <value>" to console
 end
 
 def display_guess_order(guesses)
   # use #each_with_index to iterate through each item of the guesses (an array)
-  # using puts, output each list item "Guess #<number> is <item>" to console
+  # use puts to output each list item "Guess #<number> is <item>" to console
   # hint: the number should start with 1
-  guesses.each_with_index do |guess, index| 
-    puts "Guess ##{index + 1} is #{guess}" 
-  end
 end
 
 def find_absolute_values(numbers)
   # use #map to iterate through each item of the numbers (an array)
   # return an array of absolute values of each number
-  numbers.map { |number| number.abs }
 end
 
 def find_low_inventory(inventory_list)
   # use #select to iterate through each item of the inventory_list (a hash)
   # return an array of list items with values less than 4
-  inventory_list.select { |key, value| value < 4 } 
 end
 
 def find_longest_word(word_list)
@@ -30,31 +24,16 @@ def find_longest_word(word_list)
   # return the longest word in the word_list
   # hint: the result of each iteration should be the accumulator when its 
   # length is greater than word.length (otherwise the result should be the word)
-  word_list.reduce do |memo, word|
-    if memo.length > word.length
-      memo
-    else
-      word
-    end
-  end
 end
 
 def find_longer_words(word_list, base_word)
   # use #reduce to iterate through each item of the word_list (an array)
   # return an array of words that is longer than the base_word (a string)
-  # hint: use a new array or an empty array as the initial accumulator value (memo)
-  word_list.reduce([]) do |memo, word|
-    memo << word if word.length > base_word.length
-    memo
-  end
+  # hint: use a new array or an empty array as the initial accumulator value
 end
 
 def find_word_lengths(word_list)
   # use #reduce to iterate through each item of the word_list (an array)
   # return a hash with each word as the key and its length as the value
-  # hint: use a new hash or an empty hash as the initial accumulator value (memo)
-  word_list.reduce({}) do |memo, word|
-    memo[word] = word.length
-    memo
-  end
+  # hint: use a new hash or an empty hash as the initial accumulator value
 end

--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -28,16 +28,6 @@ def longest_word(word_list)
   end
 end
 
-def longest_word_default(word_list, memo = '')
-  word_list.reduce(memo) do |memo, word|
-    if memo.length > word.length
-      memo
-    else
-      word
-    end
-  end
-end
-
 def longest_word_comparison(word_list, memo)
   word_list.reduce(memo) do |memo, word|
     if memo.length > word.length

--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -1,24 +1,35 @@
-def display_current_inventory(list)
-  list.each { |key, value| puts "#{key}, quantity: #{value}" } 
+def display_current_inventory(inventory_list)
+  # use #each to iterate through each item of the inventory_list (a hash)
+  # using puts, output each list item "<key>, quantity: <value>" to console
+  inventory_list.each { |key, value| puts "#{key}, quantity: #{value}" } 
 end
 
-def display_guess_order(array)
-  array.each_with_index do |item, index|
-    puts "Guess ##{index + 1} is #{item}"
+def display_guess_order(guesses)
+  # use #each_with_index to iterate through each item of the guesses (an array)
+  # using puts, output each list item "Guess #<number> is <item>" to console
+  # hint: the number should start with 1
+  guesses.each_with_index do |guess, index| 
+    puts "Guess ##{index + 1} is #{guess}" 
   end
 end
 
-def find_absolute_values(array)
-  array.map do |item|
-    item.abs
-  end
+def find_absolute_values(numbers)
+  # use #map to iterate through each item of the numbers (an array)
+  # return an array of absolute values of each number
+  numbers.map { |number| number.abs }
 end
 
-def find_low_inventory(list)
-  list.select { |key, value| value < 4 } 
+def find_low_inventory(inventory_list)
+  # use #select to iterate through each item of the inventory_list (a hash)
+  # return an array of list items with values less than 4
+  inventory_list.select { |key, value| value < 4 } 
 end
 
 def find_longest_word(word_list)
+  # use #reduce to iterate through each item of the word_list (an array)
+  # return the longest word in the word_list
+  # hint: the result of each iteration should be the accumulator when its 
+  # length is greater than word.length (otherwise the result should be the word)
   word_list.reduce do |memo, word|
     if memo.length > word.length
       memo
@@ -29,6 +40,9 @@ def find_longest_word(word_list)
 end
 
 def find_longer_words(word_list, base_word)
+  # use #reduce to iterate through each item of the word_list (an array)
+  # return an array of words that is longer than the base_word (a string)
+  # hint: use a new array or an empty array as the initial accumulator value (memo)
   word_list.reduce([]) do |memo, word|
     memo << word if word.length > base_word.length
     memo
@@ -36,6 +50,9 @@ def find_longer_words(word_list, base_word)
 end
 
 def find_word_lengths(word_list)
+  # use #reduce to iterate through each item of the word_list (an array)
+  # return a hash with each word as the key and its length as the value
+  # hint: use a new hash or an empty hash as the initial accumulator value (memo)
   word_list.reduce({}) do |memo, word|
     memo[word] = word.length
     memo

--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -1,19 +1,56 @@
-def current_inventory(list)
-  list.each { |key, value| puts "#{key}: #{value}" } 
+def display_current_inventory(list)
+  list.each { |key, value| puts "#{key}, quantity: #{value}" } 
 end
 
-def index_method(array)
+def display_guess_order(array)
   array.each_with_index do |item, index|
-    puts item if index % 3 == 0
+    puts "Guess ##{index + 1} is #{item}"
   end
 end
 
-def map_method(array)
+def convert_to_positive(array)
   array.map do |item|
-    item.downcase.reverse.capitalize
+    item.abs
   end
 end
 
 def low_inventory(list)
   list.select { |key, value| value < 4 } 
+end
+
+def longest_word(word_list)
+  word_list.reduce do |memo, word|
+    if memo.length > word.length
+      memo
+    else
+      word
+    end
+  end
+end
+
+def longest_word_default(word_list, memo = '')
+  word_list.reduce(memo) do |memo, word|
+    if memo.length > word.length
+      memo
+    else
+      word
+    end
+  end
+end
+
+def longest_word_comparison(word_list, memo)
+  word_list.reduce(memo) do |memo, word|
+    if memo.length > word.length
+      memo
+    else
+      word
+    end
+  end
+end
+
+def word_length_list(word_list)
+  word_list.reduce({}) do |memo, word|
+    memo[word] = word.length
+    memo
+  end
 end

--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -8,17 +8,17 @@ def display_guess_order(array)
   end
 end
 
-def convert_to_positive(array)
+def find_absolute_values(array)
   array.map do |item|
     item.abs
   end
 end
 
-def low_inventory(list)
+def find_low_inventory(list)
   list.select { |key, value| value < 4 } 
 end
 
-def longest_word(word_list)
+def find_longest_word(word_list)
   word_list.reduce do |memo, word|
     if memo.length > word.length
       memo
@@ -28,17 +28,14 @@ def longest_word(word_list)
   end
 end
 
-def longest_word_comparison(word_list, memo)
-  word_list.reduce(memo) do |memo, word|
-    if memo.length > word.length
-      memo
-    else
-      word
-    end
+def find_longer_words(word_list, base_word)
+  word_list.reduce([]) do |memo, word|
+    memo << word if word.length > base_word.length
+    memo
   end
 end
 
-def word_length_list(word_list)
+def find_word_lengths(word_list)
   word_list.reduce({}) do |memo, word|
     memo[word] = word.length
     memo

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../exercises/basic_enumerable_exercises'
 
-RSpec.describe 'Method Exercises' do
+RSpec.describe 'Basic Enumerable Exercises' do
 
   describe 'display current inventory exercise' do
 
@@ -14,7 +14,7 @@ RSpec.describe 'Method Exercises' do
     end
 
     # remove the 'x' from the line below to unskip the test
-    it 'outputs item without quantity when value is nil' do
+    xit 'outputs item without quantity when value is nil' do
       expect($stdout).to receive(:puts).with("pineapples, quantity: ")
       fruit = { pineapples: nil }
       display_current_inventory(fruit)
@@ -23,7 +23,7 @@ RSpec.describe 'Method Exercises' do
   
   describe 'display guess order exercise' do
     
-    it 'outputs each guess of strings in order' do
+    xit 'outputs each guess of strings in order' do
       expect($stdout).to receive(:puts).with("Guess #1 is cookies")
       expect($stdout).to receive(:puts).with("Guess #2 is cake")
       expect($stdout).to receive(:puts).with("Guess #3 is ice cream")
@@ -31,7 +31,7 @@ RSpec.describe 'Method Exercises' do
       display_guess_order(guesses)
     end
 
-    it 'outputs each guess of integers in order' do
+    xit 'outputs each guess of integers in order' do
       expect($stdout).to receive(:puts).with("Guess #1 is 553")
       expect($stdout).to receive(:puts).with("Guess #2 is 554")
       expect($stdout).to receive(:puts).with("Guess #3 is 555")
@@ -42,13 +42,13 @@ RSpec.describe 'Method Exercises' do
 
   describe 'find absolute values exercise' do
     
-    it 'returns an array of positive integers' do
+    xit 'returns an array of positive integers' do
       numbers = [0, -7, 14, -21]
       result = [0, 7, 14, 21]
       expect(find_absolute_values(numbers)).to eq(result)
     end
 
-    it 'returns an array of positive floating point numbers' do
+    xit 'returns an array of positive floating point numbers' do
       numbers = [-3.14, 6.28, -9.42]
       result = [3.14, 6.28, 9.42]
       expect(find_absolute_values(numbers)).to eq(result)
@@ -57,13 +57,13 @@ RSpec.describe 'Method Exercises' do
 
   describe 'find low inventory exercise' do
     
-    it 'returns a hash with integer values' do
+    xit 'returns a hash with integer values' do
       fruit = { apples: 1, peaches: 4, bananas: 3, oranges: 7 }
       result = { apples: 1, bananas: 3 }
       expect(find_low_inventory(fruit)).to eq(result)
     end
 
-    it 'returns a hash with floating point number values' do
+    xit 'returns a hash with floating point number values' do
       cakes = { chocolate_cake: 2.5, vanilla_cake: 4.25, carrot_cake: 3.75 }
       result = { chocolate_cake: 2.5, carrot_cake: 3.75 }
       expect(find_low_inventory(cakes)).to eq(result)
@@ -72,12 +72,12 @@ RSpec.describe 'Method Exercises' do
 
   describe 'find longest word exercise' do
     
-    it 'returns the longest word' do
+    xit 'returns the longest word' do
       list = ['cat', 'horse', 'rabbit', 'deer', 'panda']
       expect(find_longest_word(list)).to eq('rabbit')
     end
 
-    it 'returns the last word when they are all the same length' do
+    xit 'returns the last word when they are all the same length' do
       animals = ['cat', 'dog', 'fox', 'bee', 'owl']
       expect(find_longest_word(animals)).to eq('owl')
     end
@@ -85,13 +85,13 @@ RSpec.describe 'Method Exercises' do
 
   describe 'find longer words exercise' do
     
-    it 'returns an array of words longer than the base word' do
+    xit 'returns an array of words longer than the base word' do
       animals = ['cat', 'horse', 'lion', 'panda', 'rabbit']
       result = ['horse', 'panda', 'rabbit']
       expect(find_longer_words(animals, 'bear')).to eq(result)
     end
 
-    it 'returns an empty array when they are all the same length' do
+    xit 'returns an empty array when they are all the same length' do
       animals = ['cat', 'dog', 'fox', 'bee', 'owl']
       result = []
       expect(find_longer_words(animals, 'pig')).to eq(result)
@@ -100,13 +100,13 @@ RSpec.describe 'Method Exercises' do
 
   describe 'find word length exercise' do
     
-    it 'returns a hash with rocket syntax when using strings' do
+    xit 'returns a hash with rocket syntax when using strings' do
       animals = ['cat', 'horse', 'rabbit', 'deer']
       result = { 'cat' => 3, 'horse' => 5, 'rabbit' => 6, 'deer' => 4 }
       expect(find_word_lengths(animals)).to eq(result)
     end
     
-    it 'returns a hash with symbols syntax when using symbols' do
+    xit 'returns a hash with symbols syntax when using symbols' do
       animals = [:cat, :horse, :rabbit, :deer]
       result = { cat: 3, horse: 5, rabbit: 6, deer: 4 }
       expect(find_word_lengths(animals)).to eq(result)

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -34,60 +34,71 @@ RSpec.describe 'Method Exercises' do
 
   describe 'convert to positive exercise' do
     
-    it 'outputs ...' do
-      array = [1, -2, 3]
-      expect(convert_to_positive(array)).to eq([1, 2, 3])
+    it 'returns an array of positive integers' do
+      numbers = [0, -7, 14, -21]
+      result = [0, 7, 14, 21]
+      expect(convert_to_positive(numbers)).to eq(result)
     end
 
-    it 'outputs ...' do
-      array = [1, -2, 3, 0]
-      expect(convert_to_positive(array)).to eq([1, 2, 3, 0])
+    it 'returns an array with positive floating numbers' do
+      numbers = [-3.14, 6.28, -9.42]
+      result = [3.14, 6.28, 9.42]
+      expect(convert_to_positive(numbers)).to eq(result)
     end
   end
 
   describe 'low inventory exercise' do
     
-    it 'outputs ...' do
+    it 'returns ...' do
       list = { apples: 1, bananas: 3, oranges: 7 }
       expect(low_inventory(list)).to eq({ apples: 1, bananas: 3 })
     end
 
-    it 'outputs ...' do
-      list = { apples: 1, bananas: 3, oranges: 7, pineapple: 0 }
-      expect(low_inventory(list)).to eq({ apples: 1, bananas: 3, pineapple: 0 })
+    it 'returns ...' do
+      list = { chocolate_cake: 1.5, vanilla_cake: 4.25, carrot_cake: 3.75 }
+      result = { chocolate_cake: 1.5, carrot_cake: 3.75 }
+      expect(low_inventory(list)).to eq(result)
     end
   end
 
   describe 'longest word exercise' do
     
-    it 'outputs ...' do
-      list = ['cat', 'sheep', 'bear']
-      expect(longest_word(list)).to eq('sheep')
+    it 'returns the longest word' do
+      list = ['cat', 'horse', 'deer']
+      expect(longest_word(list)).to eq('horse')
     end
-  end
 
-  describe 'reduce with default word exercise' do
-
-    it 'outputs ...' do
-      list = ['cat', 'sheep', 'bear']
-      expect(longest_word_default(list)).to eq('sheep')
+    it 'returns the last word when they are all the same length' do
+      animals = ['cat', 'dog', 'fox', 'bee', 'owl']
+      expect(longest_word(animals)).to eq('owl')
     end
   end
 
   describe 'reduce with memo word exercise' do
     
-    it 'outputs ...' do
-      list = ['cat', 'sheep', 'bear']
-      expect(longest_word_comparison(list, 'piglet')).to eq('piglet')
+    it 'returns the longest word' do
+      animals = ['cat', 'horse', 'lion', 'panda']
+      expect(longest_word_comparison(animals, 'rabbit')).to eq('rabbit')
+    end
+
+    it 'returns the last word when they are all the same length' do
+      animals = ['cat', 'dog', 'fox', 'bee', 'owl']
+      expect(longest_word_comparison(animals, 'pig')).to eq('owl')
     end
   end
 
   describe 'word length list exercise' do
     
-    it 'outputs ...' do
-      array = ['red', 'blue', 'green']
-      result = { 'red' => 3, 'blue' => 4, 'green' => 5 }
-      expect(word_length_list(array)).to eq(result)
+    it 'returns a hash with strings and integers' do
+      animals = ['cat', 'horse', 'rabbit', 'deer']
+      result = { 'cat' => 3, 'horse' => 5, 'rabbit' => 6, 'deer' => 4 }
+      expect(word_length_list(animals)).to eq(result)
+    end
+    
+    it 'returns a hash with symbols and integers' do
+      symbols = [:cat, :horse, :rabbit, :deer]
+      result = { cat: 3, horse: 5, rabbit: 6, deer: 4 }
+      expect(word_length_list(symbols)).to eq(result)
     end
   end
 end

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe 'Method Exercises' do
   describe 'find longest word exercise' do
     
     it 'returns the longest word' do
-      list = ['cat', 'horse', 'deer']
-      expect(find_longest_word(list)).to eq('horse')
+      list = ['cat', 'horse', 'rabbit', 'deer', 'panda']
+      expect(find_longest_word(list)).to eq('rabbit')
     end
 
     it 'returns the last word when they are all the same length' do

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -3,118 +3,91 @@ require_relative '../exercises/basic_enumerable_exercises'
 
 RSpec.describe 'Method Exercises' do
 
-  describe 'exercise' do
+  describe 'display current inventory exercise' do
 
     it 'outputs each inventory item' do
       list = { apples: 1, bananas: 3, oranges: 7 }
-      expect($stdout).to receive(:puts).with("apples: 1")
-      expect($stdout).to receive(:puts).with("bananas: 3")
-      expect($stdout).to receive(:puts).with("oranges: 7")
-      current_inventory(list)
+      expect($stdout).to receive(:puts).with("apples, quantity: 1")
+      expect($stdout).to receive(:puts).with("bananas, quantity: 3")
+      expect($stdout).to receive(:puts).with("oranges, quantity: 7")
+      display_current_inventory(list)
     end
 
     # remove the 'x' from the line below to unskip the test
     it 'outputs ... when inventory item is nil' do
-      list = { pineapple: nil }
-      expect($stdout).to receive(:puts).with("pineapple: ")
-      current_inventory(list)
+      list = { pineapples: nil }
+      expect($stdout).to receive(:puts).with("pineapples, quantity: ")
+      display_current_inventory(list)
     end
   end
   
-  describe 'exercise' do
+  describe 'display guess order exercise' do
     
     it 'outputs ...' do
-      array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-      expect($stdout).to receive(:puts).with(0)
-      expect($stdout).to receive(:puts).with(3)
-      expect($stdout).to receive(:puts).with(6)
-      expect($stdout).to receive(:puts).with(9)
-      index_method(array)
-    end
-
-    it 'outputs ... when nil' do
-      array = [nil, nil, nil]
-      expect($stdout).to receive(:puts).with(nil)
-      index_method(array)
+      guesses = ['cookies', 'cake', 'ice cream']
+      expect($stdout).to receive(:puts).with("Guess #1 is cookies")
+      expect($stdout).to receive(:puts).with("Guess #2 is cake")
+      expect($stdout).to receive(:puts).with("Guess #3 is ice cream")
+      display_guess_order(guesses)
     end
   end
 
-  describe 'exercise' do
+  describe 'convert to positive exercise' do
     
     it 'outputs ...' do
-      array = ['Amy', 'Brad', 'Carl', 'Drew']
-      expect(map_method(array)).to eq(['Yma', 'Darb', 'Lrac', 'Werd'])
+      array = [1, -2, 3]
+      expect(convert_to_positive(array)).to eq([1, 2, 3])
     end
-    
+
     it 'outputs ...' do
-      array = ['Larry', 'Max', 'Ned']
-      expect(map_method(array)).to eq(["Yrral", "Xam", "Den"])
+      array = [1, -2, 3, 0]
+      expect(convert_to_positive(array)).to eq([1, 2, 3, 0])
     end
   end
 
-  describe 'exercise' do
+  describe 'low inventory exercise' do
     
     it 'outputs ...' do
       list = { apples: 1, bananas: 3, oranges: 7 }
-      expect(low_inventory(list)).to eq(list = { apples: 1, bananas: 3 })
+      expect(low_inventory(list)).to eq({ apples: 1, bananas: 3 })
     end
 
     it 'outputs ...' do
       list = { apples: 1, bananas: 3, oranges: 7, pineapple: 0 }
-      expect(low_inventory(list)).to eq(list = { apples: 1, bananas: 3, pineapple: 0 })
+      expect(low_inventory(list)).to eq({ apples: 1, bananas: 3, pineapple: 0 })
+    end
+  end
+
+  describe 'longest word exercise' do
+    
+    it 'outputs ...' do
+      list = ['cat', 'sheep', 'bear']
+      expect(longest_word(list)).to eq('sheep')
+    end
+  end
+
+  describe 'reduce with default word exercise' do
+
+    it 'outputs ...' do
+      list = ['cat', 'sheep', 'bear']
+      expect(longest_word_default(list)).to eq('sheep')
+    end
+  end
+
+  describe 'reduce with memo word exercise' do
+    
+    it 'outputs ...' do
+      list = ['cat', 'sheep', 'bear']
+      expect(longest_word_comparison(list, 'piglet')).to eq('piglet')
+    end
+  end
+
+  describe 'word length list exercise' do
+    
+    it 'outputs ...' do
+      array = ['red', 'blue', 'green']
+      result = { 'red' => 3, 'blue' => 4, 'green' => 5 }
+      expect(word_length_list(array)).to eq(result)
     end
   end
 end
-
-# Lesson: https://www.theodinproject.com/courses/ruby-programming/lessons/basic-enumerable-methods
-
-#  each
-#  each_with_index
-#  map
-#  select
-#  reduce
-#  bang versions -> SKIP?
-
-# EACH
-# Chuck Norris example?
-# friends.each { |friend| puts "Hello, " + friend }
-
-# my_array.each do |num|
-#   num *= 2
-#   puts "The new number is #{num}."
-# end
-
-# my_hash.each { |key, value| puts "#{key} is #{value}" }
-
-# my_hash.each { |pair| puts "the pair is #{pair}" }
-# contact_info = { 'name' => 'Bob', 'phone' => '111-111-1111' } 
-# contact_info.each { |key, value| print key + ' = ' + value + "\n" } 
-
-# EACH WITH INDEX
-# fruits.each_with_index { |fruit, index| puts fruit if index.even? }
-# Just like with the #each method, #each_with_index returns the original array it’s called on.
-
-# MAP
-# friends.map { |friend| friend.upcase }
-
-# my_order.map { |item| item.gsub('medium', 'extra large') }
-
-# salaries.map { |salary| salary - 700 }
-# Whenever you want to return a new array with the results of running your block of code, #map is the method for you!
-
-# SELECT
-# friends.select { |friend| friend != 'Brian' }
-
-# responses = { 'Sharon' => 'yes', 'Leo' => 'no', 'Leila' => 'no', 'Arun' => 'yes' }
-# responses.select { |person, response| response == 'yes'}
-
-# REDUCE
-# my_numbers.reduce { |sum, number| sum + number }
-# my_numbers.reduce(1000) { |sum, number| sum + number }
-
-# votes = ["Bob's Dirty Burger Shack", "St. Mark's Bistro", "Bob's Dirty Burger Shack"]
-
-# votes.reduce(Hash.new(0)) do |result, vote|
-#   result[vote] += 1
-#   result
-# end

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -6,99 +6,110 @@ RSpec.describe 'Method Exercises' do
   describe 'display current inventory exercise' do
 
     it 'outputs each inventory item' do
-      list = { apples: 1, bananas: 3, oranges: 7 }
       expect($stdout).to receive(:puts).with("apples, quantity: 1")
       expect($stdout).to receive(:puts).with("bananas, quantity: 3")
       expect($stdout).to receive(:puts).with("oranges, quantity: 7")
-      display_current_inventory(list)
+      fruit = { apples: 1, bananas: 3, oranges: 7 }
+      display_current_inventory(fruit)
     end
 
     # remove the 'x' from the line below to unskip the test
-    it 'outputs ... when inventory item is nil' do
-      list = { pineapples: nil }
+    it 'outputs item without quantity when value is nil' do
       expect($stdout).to receive(:puts).with("pineapples, quantity: ")
-      display_current_inventory(list)
+      fruit = { pineapples: nil }
+      display_current_inventory(fruit)
     end
   end
   
   describe 'display guess order exercise' do
     
-    it 'outputs ...' do
-      guesses = ['cookies', 'cake', 'ice cream']
+    it 'outputs each guess of strings in order' do
       expect($stdout).to receive(:puts).with("Guess #1 is cookies")
       expect($stdout).to receive(:puts).with("Guess #2 is cake")
       expect($stdout).to receive(:puts).with("Guess #3 is ice cream")
+      guesses = ['cookies', 'cake', 'ice cream']
+      display_guess_order(guesses)
+    end
+
+    it 'outputs each guess of integers in order' do
+      expect($stdout).to receive(:puts).with("Guess #1 is 553")
+      expect($stdout).to receive(:puts).with("Guess #2 is 554")
+      expect($stdout).to receive(:puts).with("Guess #3 is 555")
+      guesses = [553, 554, 555]
       display_guess_order(guesses)
     end
   end
 
-  describe 'convert to positive exercise' do
+  describe 'find absolute values exercise' do
     
     it 'returns an array of positive integers' do
       numbers = [0, -7, 14, -21]
       result = [0, 7, 14, 21]
-      expect(convert_to_positive(numbers)).to eq(result)
+      expect(find_absolute_values(numbers)).to eq(result)
     end
 
-    it 'returns an array with positive floating numbers' do
+    it 'returns an array of positive floating point numbers' do
       numbers = [-3.14, 6.28, -9.42]
       result = [3.14, 6.28, 9.42]
-      expect(convert_to_positive(numbers)).to eq(result)
+      expect(find_absolute_values(numbers)).to eq(result)
     end
   end
 
-  describe 'low inventory exercise' do
+  describe 'find low inventory exercise' do
     
-    it 'returns ...' do
-      list = { apples: 1, bananas: 3, oranges: 7 }
-      expect(low_inventory(list)).to eq({ apples: 1, bananas: 3 })
+    it 'returns a hash with integer values' do
+      fruit = { apples: 1, peaches: 4, bananas: 3, oranges: 7 }
+      result = { apples: 1, bananas: 3 }
+      expect(find_low_inventory(fruit)).to eq(result)
     end
 
-    it 'returns ...' do
-      list = { chocolate_cake: 1.5, vanilla_cake: 4.25, carrot_cake: 3.75 }
-      result = { chocolate_cake: 1.5, carrot_cake: 3.75 }
-      expect(low_inventory(list)).to eq(result)
+    it 'returns a hash with floating point number values' do
+      cakes = { chocolate_cake: 2.5, vanilla_cake: 4.25, carrot_cake: 3.75 }
+      result = { chocolate_cake: 2.5, carrot_cake: 3.75 }
+      expect(find_low_inventory(cakes)).to eq(result)
     end
   end
 
-  describe 'longest word exercise' do
+  describe 'find longest word exercise' do
     
     it 'returns the longest word' do
       list = ['cat', 'horse', 'deer']
-      expect(longest_word(list)).to eq('horse')
+      expect(find_longest_word(list)).to eq('horse')
     end
 
     it 'returns the last word when they are all the same length' do
       animals = ['cat', 'dog', 'fox', 'bee', 'owl']
-      expect(longest_word(animals)).to eq('owl')
+      expect(find_longest_word(animals)).to eq('owl')
     end
   end
 
-  describe 'reduce with memo word exercise' do
+  describe 'find longer words exercise' do
     
-    it 'returns the longest word' do
-      animals = ['cat', 'horse', 'lion', 'panda']
-      expect(longest_word_comparison(animals, 'rabbit')).to eq('rabbit')
+    it 'returns an array of words longer than the base word' do
+      animals = ['cat', 'horse', 'lion', 'panda', 'rabbit']
+      result = ['horse', 'panda', 'rabbit']
+      expect(find_longer_words(animals, 'bear')).to eq(result)
     end
 
-    it 'returns the last word when they are all the same length' do
+    it 'returns an empty array when they are all the same length' do
       animals = ['cat', 'dog', 'fox', 'bee', 'owl']
-      expect(longest_word_comparison(animals, 'pig')).to eq('owl')
+      result = []
+      expect(find_longer_words(animals, 'pig')).to eq(result)
     end
   end
 
-  describe 'word length list exercise' do
+  describe 'find word length exercise' do
     
-    it 'returns a hash with strings and integers' do
+    it 'returns a hash with rocket syntax when using strings' do
       animals = ['cat', 'horse', 'rabbit', 'deer']
       result = { 'cat' => 3, 'horse' => 5, 'rabbit' => 6, 'deer' => 4 }
-      expect(word_length_list(animals)).to eq(result)
+      expect(find_word_lengths(animals)).to eq(result)
     end
     
-    it 'returns a hash with symbols and integers' do
-      symbols = [:cat, :horse, :rabbit, :deer]
+    it 'returns a hash with symbols syntax when using symbols' do
+      animals = [:cat, :horse, :rabbit, :deer]
       result = { cat: 3, horse: 5, rabbit: 6, deer: 4 }
-      expect(word_length_list(symbols)).to eq(result)
+      expect(find_word_lengths(animals)).to eq(result)
     end
   end
 end

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+require_relative '../exercises/basic_enumerable_exercises'
+
+RSpec.describe 'Method Exercises' do
+
+  describe 'exercise' do
+
+    it 'outputs each inventory item' do
+      list = { apples: 1, bananas: 3, oranges: 7 }
+      expect($stdout).to receive(:puts).with("apples: 1")
+      expect($stdout).to receive(:puts).with("bananas: 3")
+      expect($stdout).to receive(:puts).with("oranges: 7")
+      current_inventory(list)
+    end
+
+    # remove the 'x' from the line below to unskip the test
+    it 'outputs ... when inventory item is nil' do
+      list = { pineapple: nil }
+      expect($stdout).to receive(:puts).with("pineapple: ")
+      current_inventory(list)
+    end
+  end
+  
+  describe 'exercise' do
+    
+    it 'outputs ...' do
+      array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      expect($stdout).to receive(:puts).with(0)
+      expect($stdout).to receive(:puts).with(3)
+      expect($stdout).to receive(:puts).with(6)
+      expect($stdout).to receive(:puts).with(9)
+      index_method(array)
+    end
+
+    it 'outputs ... when nil' do
+      array = [nil, nil, nil]
+      expect($stdout).to receive(:puts).with(nil)
+      index_method(array)
+    end
+  end
+
+  describe 'exercise' do
+    
+    it 'outputs ...' do
+      array = ['Amy', 'Brad', 'Carl', 'Drew']
+      expect(map_method(array)).to eq(['Yma', 'Darb', 'Lrac', 'Werd'])
+    end
+    
+    it 'outputs ...' do
+      array = ['Larry', 'Max', 'Ned']
+      expect(map_method(array)).to eq(["Yrral", "Xam", "Den"])
+    end
+  end
+
+  describe 'exercise' do
+    
+    it 'outputs ...' do
+      list = { apples: 1, bananas: 3, oranges: 7 }
+      expect(low_inventory(list)).to eq(list = { apples: 1, bananas: 3 })
+    end
+
+    it 'outputs ...' do
+      list = { apples: 1, bananas: 3, oranges: 7, pineapple: 0 }
+      expect(low_inventory(list)).to eq(list = { apples: 1, bananas: 3, pineapple: 0 })
+    end
+  end
+end
+
+# Lesson: https://www.theodinproject.com/courses/ruby-programming/lessons/basic-enumerable-methods
+
+#  each
+#  each_with_index
+#  map
+#  select
+#  reduce
+#  bang versions -> SKIP?
+
+# EACH
+# Chuck Norris example?
+# friends.each { |friend| puts "Hello, " + friend }
+
+# my_array.each do |num|
+#   num *= 2
+#   puts "The new number is #{num}."
+# end
+
+# my_hash.each { |key, value| puts "#{key} is #{value}" }
+
+# my_hash.each { |pair| puts "the pair is #{pair}" }
+# contact_info = { 'name' => 'Bob', 'phone' => '111-111-1111' } 
+# contact_info.each { |key, value| print key + ' = ' + value + "\n" } 
+
+# EACH WITH INDEX
+# fruits.each_with_index { |fruit, index| puts fruit if index.even? }
+# Just like with the #each method, #each_with_index returns the original array it’s called on.
+
+# MAP
+# friends.map { |friend| friend.upcase }
+
+# my_order.map { |item| item.gsub('medium', 'extra large') }
+
+# salaries.map { |salary| salary - 700 }
+# Whenever you want to return a new array with the results of running your block of code, #map is the method for you!
+
+# SELECT
+# friends.select { |friend| friend != 'Brian' }
+
+# responses = { 'Sharon' => 'yes', 'Leo' => 'no', 'Leila' => 'no', 'Arun' => 'yes' }
+# responses.select { |person, response| response == 'yes'}
+
+# REDUCE
+# my_numbers.reduce { |sum, number| sum + number }
+# my_numbers.reduce(1000) { |sum, number| sum + number }
+
+# votes = ["Bob's Dirty Burger Shack", "St. Mark's Bistro", "Bob's Dirty Burger Shack"]
+
+# votes.reduce(Hash.new(0)) do |result, vote|
+#   result[vote] += 1
+#   result
+# end

--- a/ruby_basics/9_basic_enumerables/spec/spec_helper.rb
+++ b/ruby_basics/9_basic_enumerables/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/ruby_basics/README.md
+++ b/ruby_basics/README.md
@@ -29,3 +29,7 @@ These exercises are designed to compliment the [Ruby Basic lessons](https://www.
 #### 8.Methods
 
 - [ ] Method Exercises 
+
+#### 9.Basic Enumerables
+
+- [ ] Basic Enumerable Exercises 


### PR DESCRIPTION
I created an example for each of the methods listed in the issue, except for the following:

For `#reduce`, I created three examples because this is the hardest one for people to wrap their heads around. Please let me know if this is too much, but I wish I would have had practice using it in these different ways.

For bang versions, I did not create any examples for the following reasons. The lesson states "It’s best practice to avoid using these methods". Also, much like I stated in the method exercises, it does not look any different as the return value of a method. This would make more sense later in the curriculum using an instance variable.

For each exercise, I listed the intended enumerable to use, to eliminate any chance for confusion. In addition, I provided a hint for a few of the exercises to help clarify the logic needed inside the enumerable. 

Resolves #13 