### PR TITLE
Clarify wording by replacing index with element

### DIFF
--- a/ruby_basics/6_arrays/exercises/array_exercises.rb
+++ b/ruby_basics/6_arrays/exercises/array_exercises.rb
@@ -6,16 +6,16 @@ def nested_array(number)
   # return an array containing the number of empty arrays
 end
 
-def first_index(array)
-  # return the first index of the array
+def first_element(array)
+  # return the first element of the array
+end
+
+def third_element(array)
+  # return the third element of the array
 end
 
 def last_three_elements(array)
   # return the last 3 elements of the array
-end
-
-def second_index(array)
-  # return the second index of the array
 end
 
 def add_element(array)

--- a/ruby_basics/6_arrays/spec/array_exercises_spec.rb
+++ b/ruby_basics/6_arrays/spec/array_exercises_spec.rb
@@ -25,14 +25,25 @@ RSpec.describe 'Array Exercises' do
     end
   end
 
-  describe 'first index exercise' do
+  describe 'first element exercise' do
 
-    xit 'returns the first index of an array of numbers' do
-      expect(first_index([2, 4, 6, 8, 10])).to eq(2)
+    xit 'returns the first element of an array of numbers' do
+      expect(first_element([2, 4, 6, 8, 10])).to eq(2)
     end
 
-    xit 'returns the first index of an array of strings' do
-      expect(first_index(['foo', 'bar'])).to eq('foo')
+    xit 'returns the first element of an array of strings' do
+      expect(first_element(['foo', 'bar'])).to eq('foo')
+    end
+  end
+
+  describe 'third element exercise' do
+
+    xit 'returns the third element of an array of numbers' do
+      expect(third_element([2, 4, 6, 8, 10])).to eq(6)
+    end
+
+    xit 'returns nil if the array does not have a third element' do
+      expect(third_element(['foo', 'bar'])).to eq(nil)
     end
   end
 
@@ -44,17 +55,6 @@ RSpec.describe 'Array Exercises' do
 
     xit 'returns all of the elements when there are less than 3 elements' do
       expect(last_three_elements(['foo', 'bar'])).to eq(['foo', 'bar'])
-    end
-  end
-
-  describe 'second index exercise' do
-
-    xit 'returns the second index of an array' do
-      expect(second_index([2, 4, 6, 8, 10])).to eq(6)
-    end
-
-    xit 'returns nil if the array does not have a second index' do
-      expect(second_index(['foo', 'bar'])).to eq(nil)
     end
   end
 


### PR DESCRIPTION
The wording of `first_index` and `third_index` was incorrect and needed to be changed to `first_element` and `third_element`. This resolves #27 

In addition, I re-arranged the order of these exercises. It would have been `first_element`, `last_three_elements`, and then `third_element` and I believe it is much more clear to have `first_element`, `third_element`, and then the `last_three_elements`. This re-arrangement causes a bit of confusion on the diff, but this change helps improve the flow of these exercises.

