### PR TITLE
Update instructions: find_low_inventory returns a hash, not an array

### DIFF
--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -16,7 +16,7 @@ end
 
 def find_low_inventory(inventory_list)
   # use #select to iterate through each item of the inventory_list (a hash)
-  # return an array of list items with values less than 4
+  # return a hash of items with values less than 4
 end
 
 def find_longest_word(word_list)


### PR DESCRIPTION
I noticed that the commented instructions for the method `find_low_inventory` in **9: Basic Enumerables** encourage the student to *"return an array of list items with values less than 4"*. 

However, the `rspec` file is testing this method for a hash, not an array. For example:
```ruby
describe 'find low inventory exercise' do

  it 'returns a hash with integer values' do
    fruit = {apples: 1, peaches: 4, bananas: 3, oranges: 7}
    result = {apples: 1, bananas: 3}
    expect(find_low_inventory(fruit)).to eq(result)
  end

end
```

It would make it more clear for future students if we changed the instructions, as I have done so in this PR. Personally, at first, I thought that we were only supposed to return an array of the keys!