### PR TITLE
Remove nested exercise

### DIFF
--- a/ruby_basics/6_arrays/exercises/array_exercises.rb
+++ b/ruby_basics/6_arrays/exercises/array_exercises.rb
@@ -2,10 +2,6 @@ def nil_array(number)
   # return an array containing `nil` the given number of times
 end
 
-def nested_array(number)
-  # return an array containing nested empty arrays the given number of times
-end
-
 def first_element(array)
   # return the first element of the array
 end

--- a/ruby_basics/6_arrays/spec/array_exercises_spec.rb
+++ b/ruby_basics/6_arrays/spec/array_exercises_spec.rb
@@ -14,17 +14,6 @@ RSpec.describe 'Array Exercises' do
     end
   end
 
-  describe 'nested array exercise' do
-    
-    xit 'returns a nested array with 4 empty arrays' do
-      expect(nested_array(4)).to eq([[], [], [], []])
-    end
-    
-    xit 'returns a nested array with 3 empty arrays' do
-      expect(nested_array(3)).to eq([[], [], []])
-    end
-  end
-
   describe 'first element exercise' do
 
     xit 'returns the first element of an array of numbers' do


### PR DESCRIPTION
Removed this nested array example because the corresponding example in the lesson was removed (due to the mutability of the nested arrays). 