### PR TITLE
Remove two reduce exercises and add tip

### DIFF
--- a/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
+++ b/ruby_basics/9_basic_enumerables/exercises/basic_enumerable_exercises.rb
@@ -19,21 +19,8 @@ def find_low_inventory(inventory_list)
   # return a hash of items with values less than 4
 end
 
-def find_longest_word(word_list)
-  # use #reduce to iterate through each item of the word_list (an array)
-  # return the longest word in the word_list
-  # hint: the result of each iteration should be the accumulator when its 
-  # length is greater than word.length (otherwise the result should be the word)
-end
-
-def find_longer_words(word_list, base_word)
-  # use #reduce to iterate through each item of the word_list (an array)
-  # return an array of words that is longer than the base_word (a string)
-  # hint: use a new array or an empty array as the initial accumulator value
-end
-
 def find_word_lengths(word_list)
   # use #reduce to iterate through each item of the word_list (an array)
   # return a hash with each word as the key and its length as the value
-  # hint: use a new hash or an empty hash as the initial accumulator value
+  # hint: look at the documentation and review the reduce examples in basic enumerable lesson
 end

--- a/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
+++ b/ruby_basics/9_basic_enumerables/spec/basic_enumerable_exercises_spec.rb
@@ -70,34 +70,6 @@ RSpec.describe 'Basic Enumerable Exercises' do
     end
   end
 
-  describe 'find longest word exercise' do
-    
-    xit 'returns the longest word' do
-      list = ['cat', 'horse', 'rabbit', 'deer', 'panda']
-      expect(find_longest_word(list)).to eq('rabbit')
-    end
-
-    xit 'returns the last word when they are all the same length' do
-      animals = ['cat', 'dog', 'fox', 'bee', 'owl']
-      expect(find_longest_word(animals)).to eq('owl')
-    end
-  end
-
-  describe 'find longer words exercise' do
-    
-    xit 'returns an array of words longer than the base word' do
-      animals = ['cat', 'horse', 'lion', 'panda', 'rabbit']
-      result = ['horse', 'panda', 'rabbit']
-      expect(find_longer_words(animals, 'bear')).to eq(result)
-    end
-
-    xit 'returns an empty array when they are all the same length' do
-      animals = ['cat', 'dog', 'fox', 'bee', 'owl']
-      result = []
-      expect(find_longer_words(animals, 'pig')).to eq(result)
-    end
-  end
-
   describe 'find word length exercise' do
     
     xit 'returns a hash with rocket syntax when using strings' do


### PR DESCRIPTION
As discussed in Discord, removing these two exercises will also remove the emphasis of reduce in this file. In addition, I added a note to review the examples in the lesson, since it walks through a very similar example. 