### PR TITLE
Add Predicate enumerable exercises

### DIFF
--- a/ruby_basics/10_predicate_enumerables/.rspec
+++ b/ruby_basics/10_predicate_enumerables/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/ruby_basics/10_predicate_enumerables/exercises/predicate_enumerable_exercises.rb
+++ b/ruby_basics/10_predicate_enumerables/exercises/predicate_enumerable_exercises.rb
@@ -1,0 +1,19 @@
+def coffee_drink?(drink_list)
+  # use #include? to return true when the drink_list (array) contains the string "coffee" or "espresso"
+end
+
+def correct_guess?(guess_list, answer)
+  # use #any? to return true when any element of the guess_list (array) equals the answer (number)
+end
+
+def recent_years?(year_list)
+  # use #all? to return true when all of the years in the year_list (array) are between 2011 and 2021
+end
+
+def correct_format?(word_list)
+  # use #none? to return true when none of the words in the word_list (array) are in upcase
+end
+
+def valid_scores?(score_list, perfect_score)
+  # use #one? to return true when only one value in the score_list (hash) is equal to the perfect_score (number)
+end

--- a/ruby_basics/10_predicate_enumerables/spec/predicate_enumerable_exercises_spec.rb
+++ b/ruby_basics/10_predicate_enumerables/spec/predicate_enumerable_exercises_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Predicate Enumerable Exercises' do
       expect(coffee_drink?(list)).to be true
     end
 
-    xit 'returns false when coffee or espress is not included' do
+    xit 'returns false when coffee or espresso is not included' do
       list = ["tea", "water", "milk"]
       expect(coffee_drink?(list)).to be false
     end

--- a/ruby_basics/10_predicate_enumerables/spec/predicate_enumerable_exercises_spec.rb
+++ b/ruby_basics/10_predicate_enumerables/spec/predicate_enumerable_exercises_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+require_relative '../exercises/predicate_enumerable_exercises'
+
+RSpec.describe 'Predicate Enumerable Exercises' do
+
+  describe 'coffee drink exercise' do
+
+    it 'returns true when coffee is included' do
+      list = ["coffee", "water", "tea"]
+      expect(coffee_drink?(list)).to be true
+    end
+    
+    # remove the 'x' from the line below to unskip the test
+    xit 'returns true when espresso is included' do
+      list = ["milk", "juice", "espresso"]
+      expect(coffee_drink?(list)).to be true
+    end
+
+    xit 'returns false when coffee or espress is not included' do
+      list = ["tea", "water", "milk"]
+      expect(coffee_drink?(list)).to be false
+    end
+
+    xit 'returns false when the list is empty' do
+      list = []
+      expect(coffee_drink?(list)).to be false
+    end
+  end
+
+  describe 'correct guess exercise' do
+
+    xit 'returns true when the list contains the answer' do
+      list = [2, 3, 4, 5]
+      answer = 5
+      expect(correct_guess?(list, answer)).to be true
+    end
+
+    xit 'returns false when the list does not contain the answer' do
+      list = [6, 7, 8, 9]
+      answer = 5
+      expect(correct_guess?(list, answer)).to be false
+    end
+
+    xit 'returns false when the list is empty' do
+      list = []
+      answer = 5
+      expect(correct_guess?(list, answer)).to be false
+    end
+  end
+
+  describe 'recent years exercise' do
+
+    xit 'returns true when all of the years are between 2011 and 2021' do
+      list = [2011, 2021, 2016]
+      expect(recent_years?(list)).to be true
+    end
+
+    xit 'returns false when one year is not between 2011 and 2021' do
+      list = [2018, 2001, 2014]
+      expect(recent_years?(list)).to be false
+    end
+
+    xit 'returns true when the list is empty' do
+      list = []
+      expect(recent_years?(list)).to be true
+    end
+  end
+
+  describe 'correct format exercise' do
+
+    xit 'returns true when none of the words in the list are in upcase' do
+      list = ["Pepsi", "Coke", "Dr. Pepper"]
+      expect(correct_format?(list)).to be true
+    end
+
+    xit 'returns false when at least one word in the list is in upcase' do
+      list = ["PEPSI", "Coke", "Dr. Pepper"]
+      expect(correct_format?(list)).to be false
+    end
+
+    xit 'returns true when the list is empty' do
+      list = []
+      expect(correct_format?(list)).to be true
+    end
+  end
+
+  describe 'valid scores exercise' do
+
+    xit 'returns true when only one score is a 10' do
+      list = { easy_to_read: 10, uses_best_practices: 8, clever: 7 }
+      perfect_score = 10
+      expect(valid_scores?(list, perfect_score)).to be true
+    end
+
+    xit 'returns false when more than one score is a 10' do
+      list = { easy_to_read: 10, uses_best_practices: 10, clever: 9 }
+      perfect_score = 10
+      expect(valid_scores?(list, perfect_score)).to be false
+    end
+
+    xit 'returns false when the list is empty' do
+      list = {}
+      perfect_score = 10
+      expect(valid_scores?(list, perfect_score)).to be false
+    end
+  end
+end

--- a/ruby_basics/10_predicate_enumerables/spec/spec_helper.rb
+++ b/ruby_basics/10_predicate_enumerables/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/ruby_basics/8_methods/exercises/method_exercises.rb
+++ b/ruby_basics/8_methods/exercises/method_exercises.rb
@@ -1,4 +1,4 @@
-# Since lesson #8 is on methods, you will be writing the entire method. 
+# Since lesson #8 is on methods, you will be writing the entire method.
 # To gain more familiarity, look up the documentation for each hint.
 # Remember to unskip the corresponding tests one at a time.
 
@@ -11,7 +11,7 @@
 # method name: #common_sports
 # parameters: current_sports and favorite_sports (both arrays)
 # return value: an array containing items in both arrays
-# hint: use Array#intersection 
+# hint: use Array#intersection
 
 
 # method name: #alphabetical_list

--- a/ruby_basics/README.md
+++ b/ruby_basics/README.md
@@ -3,33 +3,37 @@ These exercises are designed to compliment the [Ruby Basic lessons](https://www.
 
 ### Usage
 
-1. First change directory into the lesson directory, for example `cd 1_data_types`
+1. First change directory into the lesson directory, for example `cd 1_data_types`.
 2. Run the tests for an exercise file, for example `bundle exec rspec spec/numbers_exercises_spec.rb`. The first test will fail and the rest will be skipped.
-3. Open that corresponding exercise file in your text editor, in this case the `exercises/numbers_exercises.rb` file
+3. Open that corresponding exercise file in your text editor, in this case the `exercises/numbers_exercises.rb` file.
 4. Write the code to get the failing test to pass in the exercise file and run the tests again to verify it passes.
 5. Go into the test file and unskip the next test by removing the `x` from `xit`.
 6. Run your tests again `bundle exec rspec spec/numbers_exercises_spec.rb` the second test should now be failing.
-7. Repeat the steps from step 2 until no more tests are skipped and all are passing. 
+7. Repeat the steps from step 2 until no more tests are skipped and all are passing.
 
 ###  Contents
 
 #### 1.Basic Data Types
 
-- [ ] Numbers Exercises 
-- [ ] Strings Exercises 
+- [ ] Numbers Exercises
+- [ ] Strings Exercises
 
 #### 6.Arrays
 
-- [ ] Array Exercises 
+- [ ] Array Exercises
 
 #### 7.Hashes
 
-- [ ] Hash Exercises 
+- [ ] Hash Exercises
 
 #### 8.Methods
 
-- [ ] Method Exercises 
+- [ ] Method Exercises
 
 #### 9.Basic Enumerables
 
-- [ ] Basic Enumerable Exercises 
+- [ ] Basic Enumerable Exercises
+
+#### 10.Predicate Enumerables
+
+- [ ] Predicate Enumerable Exercises


### PR DESCRIPTION
The issue listed an exercise for `#select`, but that is covered in the basic enumerable exercise. Instead, I added an exercise for `#one?` 

Since the lesson included a note to be aware of how some of these methods behave with an empty array or hash, I included an empty one for each method. 

Please let me know if any of these examples seem hard to understand.

Closes issue #14 