### PR TITLE
Update ruby_basics readme with spec running tip

### DIFF
--- a/ruby_basics/README.md
+++ b/ruby_basics/README.md
@@ -11,6 +11,8 @@ These exercises are designed to compliment the [Ruby Basic lessons](https://www.
 6. Run your tests again `bundle exec rspec spec/numbers_exercises_spec.rb` the second test should now be failing.
 7. Repeat the steps from step 2 until no more tests are skipped and all are passing.
 
+**TIP**: When there is only one exercise file in a directory (such as in `6_arrays`) you can omit the path to the file and just enter `bundle exec rspec` to run the tests in that file.
+
 ###  Contents
 
 #### 1.Basic Data Types


### PR DESCRIPTION
Tell students that they can omit the path to the spec file when there is only one spec file in a directory.

Closes #33 