### PR TITLE
Update bundler version to 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rspec (~> 3.9)
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
Currently the version of bundler required is way behind the version installed with the version of Ruby which we tell students to install. This causes students to have to install the older bundler version to run the exercises which may be confusing at this stage.

This PR will update the required bundler version to the version installed with Ruby 2.7.2.