### PR TITLE
Make location of spec files more explicit in README

### DIFF
--- a/ruby_basics/README.md
+++ b/ruby_basics/README.md
@@ -7,7 +7,7 @@ These exercises are designed to complement the [Ruby Basic lessons](https://www.
 2. Run the tests for an exercise file, for example `bundle exec rspec spec/numbers_exercises_spec.rb`. The first test will fail and the rest will be skipped.
 3. Open that corresponding exercise file in your text editor, in this case the `exercises/numbers_exercises.rb` file.
 4. Write the code to get the failing test to pass in the exercise file and run the tests again to verify it passes.
-5. Go into the test file and unskip the next test by removing the `x` from `xit`.
+5. Each `exercises` folder has a corresponding `spec` folder with matching test files. For instance, you can find the tests for `exercises/numbers_exercises.rb` in `spec/numbers_exercises_spec.rb`.<br>Open the matching spec file and unskip the next test by removing the `x` from `xit`.
 6. Run your tests again `bundle exec rspec spec/numbers_exercises_spec.rb` the second test should now be failing.
 7. Repeat the steps from step 2 until no more tests are skipped and all are passing.
 

--- a/ruby_basics/README.md
+++ b/ruby_basics/README.md
@@ -7,9 +7,10 @@ These exercises are designed to complement the [Ruby Basic lessons](https://www.
 2. Run the tests for an exercise file, for example `bundle exec rspec spec/numbers_exercises_spec.rb`. The first test will fail and the rest will be skipped.
 3. Open that corresponding exercise file in your text editor, in this case the `exercises/numbers_exercises.rb` file.
 4. Write the code to get the failing test to pass in the exercise file and run the tests again to verify it passes.
-5. Each `exercises` folder has a corresponding `spec` folder with matching test files. For instance, you can find the tests for `exercises/numbers_exercises.rb` in `spec/numbers_exercises_spec.rb`.<br>Open the matching spec file and unskip the next test by removing the `x` from `xit`.
-6. Run your tests again `bundle exec rspec spec/numbers_exercises_spec.rb` the second test should now be failing.
-7. Repeat the steps from step 2 until no more tests are skipped and all are passing.
+5. Each `exercises` folder has a corresponding `spec` folder with matching test files. For instance, you can find the tests for `exercises/numbers_exercises.rb` in `spec/numbers_exercises_spec.rb`. Find and open the matching spec file.
+6. Unskip the next test by removing the `x` from `xit`.
+7. Run your tests again `bundle exec rspec spec/numbers_exercises_spec.rb` the second test should now be failing.
+8. Repeat the steps from step 2 until no more tests are skipped and all are passing.
 
 **TIP**: When there is only one exercise file in a directory (such as in `6_arrays`) you can omit the path to the file and just enter `bundle exec rspec` to run the tests in that file.
 


### PR DESCRIPTION
This change was motivated by helping 2 - 3 different people understand where to actually complete the `remove x from xit` instruction in Discord. While it's slightly more verbose / repetitive, I'd argue better to give explicit  instructions especially at a stage when things like this aren't necessarily obvious to learners.