### PR TITLE
fix: change test for 'find favorite' in nested_array_exercises_spec to better resist bad solutions

### DIFF
--- a/ruby_basics/12_nested_collections/spec/nested_array_exercises_spec.rb
+++ b/ruby_basics/12_nested_collections/spec/nested_array_exercises_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe 'Nested Array Exercises' do
     context 'when Ruby is the favorite' do
       let(:array) do
         [
-          { name: 'Ruby', is_my_favorite?: true },
           { name: 'JavaScript', is_my_favorite?: false },
+          { name: 'Ruby', is_my_favorite?: true },
           { name: 'HTML', is_my_favorite?: false }
         ]
       end


### PR DESCRIPTION
closes #64 

I just made a small change to the tests for the 'find favorite exercise' to help prevent cases like the one mentioned in the Issue.