### PR TITLE
fix: Add test to favorite number exercise

### DIFF
--- a/ruby_basics/7_hashes/exercises/hash_exercises.rb
+++ b/ruby_basics/7_hashes/exercises/hash_exercises.rb
@@ -9,7 +9,7 @@ def favorite_color(favorite_list)
 end
 
 def favorite_number(favorite_list)
-  # return the value of the number key or 42 if the key is not found
+  # use #fetch to return the value of the number key or 42 if the key is not found
 end
 
 def update_favorite_movie(favorite_list, movie)

--- a/ruby_basics/7_hashes/spec/hash_exercises_spec.rb
+++ b/ruby_basics/7_hashes/spec/hash_exercises_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe 'Hash Exercises' do
       expect(favorite_number(my_favorites)).to eq({ lucky: 7 })
     end
 
+    xit 'returns nil when a key with nil value is present' do
+      my_favorites = { color: ['orange', 'green'], number: nil }
+      expect(favorite_number(my_favorites)).to eq(nil)
+    end
+
     xit 'returns the default number when the key is not found' do
       my_favorites = { color: ['orange', 'green'], movie: 'Avengers: Endgame' }
       expect(favorite_number(my_favorites)).to eq(42)

--- a/ruby_basics/7_hashes/spec/hash_exercises_spec.rb
+++ b/ruby_basics/7_hashes/spec/hash_exercises_spec.rb
@@ -48,11 +48,6 @@ RSpec.describe 'Hash Exercises' do
       expect(favorite_number(my_favorites)).to eq({ lucky: 7 })
     end
 
-    xit 'returns nil when a key with nil value is present' do
-      my_favorites = { color: ['orange', 'green'], number: nil }
-      expect(favorite_number(my_favorites)).to eq(nil)
-    end
-
     xit 'returns the default number when the key is not found' do
       my_favorites = { color: ['orange', 'green'], movie: 'Avengers: Endgame' }
       expect(favorite_number(my_favorites)).to eq(42)


### PR DESCRIPTION
Before adding the new test to [/ruby_basics/7_hashes](https://github.com/TheOdinProject/ruby-exercises/tree/main/ruby_basics/7_hashes) it was possible to pass all tests of the "favorite number" exercise by writing the method
```
def favorite_number(favorite_list)
  # return the value of the number key or 42 if the key is not found
  result = favorite_list[:number]
  if result == nil
    return 42
  else
    return result
  end
end
```

This solution leads to the unwanted behavior that it returns 42 for a hash like
`my_favorites = { color: ['orange', 'green'], number: nil }`
where the `:number` key is present but has `nil` as value. Since the lesson text explicitly discusses problems arising from using `my_favorties[:number]` to access values of a hash concerning `nil` I added a test for this edge case which takes the hash `my_favorites` from above and expects `nil`.