### PR TITLE
find_language_facts exercise: test for use of dig method

### DIFF
--- a/ruby_basics/12_nested_collections/spec/nested_hash_exercises_spec.rb
+++ b/ruby_basics/12_nested_collections/spec/nested_hash_exercises_spec.rb
@@ -189,5 +189,10 @@ RSpec.describe 'Nested hash exercises' do
       expected_output = "its real name isn't even javascript"
       expect(find_language_facts(hash, :javascript, 1)).to eq(expected_output)
     end
+
+    xit 'returns nil for python' do
+      expected_output = nil
+      expect(find_language_facts(hash, :python, 1)).to eq(expected_output)
+    end
   end
 end


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The current solution to the `find_language_facts` exercise raises a `NoMethodError` when trying to access a `language_name` that is not listed in the `languages` hash. The [lesson](https://www.theodinproject.com/lessons/ruby-nested-collections#accessing-data) mentions the `dig` method for that specific purpose, but this is never tested in the exercises.
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds a test case with a `language_name` that does not exist in `languages`.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
I opened no issue as I figured this is a small enough change to be discussed directly in a PR.

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
The solution is updated in #86 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Data types exercise: Update spec files`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes that needs to be updated on the `solutions` branch, I have created another PR (and linked it to this PR).
