### PR TITLE
Recursion Exercises: Add total integers exercise

### DIFF
--- a/recursion/3_total_integers/.rspec
+++ b/recursion/3_total_integers/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/recursion/3_total_integers/exercises/total_integers_exercises.rb
+++ b/recursion/3_total_integers/exercises/total_integers_exercises.rb
@@ -1,0 +1,6 @@
+def total_integers(array)
+  # Count the total number of integers inside of the given array
+  # The array may be nested, and the integers inside these "inner" layers must also be counted
+  #
+  # Example: `total_integers([0, 1, [5]]) == 3`
+end

--- a/recursion/3_total_integers/spec/spec_helper.rb
+++ b/recursion/3_total_integers/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/recursion/3_total_integers/spec/total_integers_exercises_spec.rb
+++ b/recursion/3_total_integers/spec/total_integers_exercises_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require_relative '../exercises/total_integers_exercises'
+
+RSpec.describe '#total_integers' do
+  it 'returns 3 with a 3 integer array' do
+    three_int_array = [1, 2, 3]
+    expect(total_integers(three_int_array)).to eq 3
+  end
+
+  xit 'ignores non integer values' do
+    array_with_string = [1, 2, '3']
+    expect(total_integers(array_with_string)).to eq 2
+  end
+
+  xit 'ignores floating point numbers' do
+    float_array = [1.0, 2.5, 0.7]
+    expect(total_integers(float_array)).to eq 0
+  end
+
+  xit 'returns 0 with an empty nested array' do
+    empty_nested_array = [[], [], []]
+    expect(total_integers(empty_nested_array)).to eq 0
+  end
+
+  xit 'returns 2 with a deeply nested two integer array' do
+    deeply_nested_array = [[[[[[[[[[[[[[4]]]]]], 246]]]]]]]]
+    expect(total_integers(deeply_nested_array)).to eq 2
+  end
+
+  xit 'returns 3 with a complex, deeply nested three integer array' do
+    complex_array = [{}, [555], '444', [nil, 74.0, [4]], [[6]]]
+    expect(total_integers(complex_array)).to eq 3
+  end
+end

--- a/solutions/recursion/3_total_integers/.rspec
+++ b/solutions/recursion/3_total_integers/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/solutions/recursion/3_total_integers/exercises/total_integers_exercises.rb
+++ b/solutions/recursion/3_total_integers/exercises/total_integers_exercises.rb
@@ -1,0 +1,12 @@
+def total_integers(array)
+  array.sum do |element|
+    case element
+    when Integer
+      1
+    when Array
+      total_integers(element)
+    else
+      0
+    end
+  end
+end

--- a/solutions/recursion/3_total_integers/spec/spec_helper.rb
+++ b/solutions/recursion/3_total_integers/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/solutions/recursion/3_total_integers/spec/total_integers_exercises_spec.rb
+++ b/solutions/recursion/3_total_integers/spec/total_integers_exercises_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require_relative '../exercises/total_integers_exercises'
+
+RSpec.describe '#total_integers' do
+  it 'returns 3 with a 3 integer array' do
+    three_int_array = [1, 2, 3]
+    expect(total_integers(three_int_array)).to eq 3
+  end
+
+  it 'ignores non integer values' do
+    array_with_string = [1, 2, '3']
+    expect(total_integers(array_with_string)).to eq 2
+  end
+
+  it 'ignores floating point numbers' do
+    float_array = [1.0, 2.5, 0.7]
+    expect(total_integers(float_array)).to eq 0
+  end
+
+  it 'returns 0 with an empty nested array' do
+    empty_nested_array = [[], [], []]
+    expect(total_integers(empty_nested_array)).to eq 0
+  end
+
+  it 'returns 2 with a deeply nested two integer array' do
+    deeply_nested_array = [[[[[[[[[[[[[[4]]]]]], 246]]]]]]]]
+    expect(total_integers(deeply_nested_array)).to eq 2
+  end
+
+  it 'returns 3 with a complex, deeply nested three integer array' do
+    complex_array = [{}, [555], '444', [nil, 74.0, [4]], [[6]]]
+    expect(total_integers(complex_array)).to eq 3
+  end
+end


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I'm working on adding Recursion Exercises to this repo because we determined it'd be beneficial to have this content in-house. See the linked issue for more information.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds an exercise, tests, and a solution for a method called `#total_integers`. This method takes in an array, which may be nested, and recursively counts the number of integers inside the structure.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Related to #114 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Data types exercise: Update spec files`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes to exercises, they are also changed in the `solutions` folder.
