### PR TITLE
Recursion Exercises: Add exercises for pascal's triangle

### DIFF
--- a/recursion/5_pascal/.rspec
+++ b/recursion/5_pascal/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/recursion/5_pascal/exercises/pascal_exercises.rb
+++ b/recursion/5_pascal/exercises/pascal_exercises.rb
@@ -1,0 +1,18 @@
+def pascal(row_number)
+  # Pascal's triangle is modeled as follows:
+  # - The first row is `1`.
+  # - Each row can be considered to have a hidden `0` to either sides of it. So the first row could also be said to be `0, 1, 0`
+  # - To obtain the next row, we take each number and add it with its rightmost neighbor.
+  #
+  # First row: `[1]`
+  # Second row: `[0+1, 1+0]` or simply `[1, 1]`
+  # Third row: `[0+1, 1+1, 1+0]` or simply `[1, 2, 1]`
+  # Fourth row: `[0+1, 1+2, 2+1, 1+0]` or simply `[1, 3, 3, 1]`
+  #
+  #
+  # The pattern continues forever.
+  #
+  # Your task is to create a *recursive* function, `pascal` - that will take an input `n` and output the `n`th pascal's row as an array of numbers.
+  #
+  # For example, `pascal(3)` should return `[1, 2, 1]`.
+end

--- a/recursion/5_pascal/spec/pascal_exercises_spec.rb
+++ b/recursion/5_pascal/spec/pascal_exercises_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require_relative '../exercises/pascal_exercises'
+
+RSpec.describe '#pascal' do
+  it 'gets the first row of the pascal triangle' do
+    expect(pascal(1)).to eq([1])
+  end
+
+  xit 'gets the second row of the pascal triangle' do
+    expect(pascal(2)).to eq([1, 1])
+  end
+
+  xit 'gets the third row of the pascal triangle' do
+    expect(pascal(3)).to eq([1, 2, 1])
+  end
+
+  xit 'gets the fourth row of the pascal triangle' do
+    expect(pascal(4)).to eq([1, 3, 3, 1])
+  end
+
+  xit 'gets the fifth row of the pascal triangle' do
+    expect(pascal(5)).to eq([1, 4, 6, 4, 1])
+  end
+
+  xit 'gets the sixth row of the pascal triangle' do
+    expect(pascal(6)).to eq([1, 5, 10, 10, 5, 1])
+  end
+
+  xit 'gets the seventh row of the pascal triangle' do
+    expect(pascal(7)).to eq([1, 6, 15, 20, 15, 6, 1])
+  end
+end

--- a/recursion/5_pascal/spec/spec_helper.rb
+++ b/recursion/5_pascal/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/solutions/recursion/5_pascal/.rspec
+++ b/solutions/recursion/5_pascal/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/solutions/recursion/5_pascal/exercises/pascal_exercises.rb
+++ b/solutions/recursion/5_pascal/exercises/pascal_exercises.rb
@@ -1,0 +1,9 @@
+def pascal(row_number)
+  current_line = [1]
+  return current_line if row_number == 1
+
+  previous_line = pascal(row_number - 1) + [0]
+  previous_line.each_cons(2) { |a, b| current_line << a + b }
+
+  current_line
+end

--- a/solutions/recursion/5_pascal/spec/pascal_exercises_spec.rb
+++ b/solutions/recursion/5_pascal/spec/pascal_exercises_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require_relative '../exercises/pascal_exercises'
+
+RSpec.describe '#pascal' do
+  it 'gets the first row of the pascal triangle' do
+    expect(pascal(1)).to eq([1])
+  end
+
+  it 'gets the second row of the pascal triangle' do
+    expect(pascal(2)).to eq([1, 1])
+  end
+
+  it 'gets the third row of the pascal triangle' do
+    expect(pascal(3)).to eq([1, 2, 1])
+  end
+
+  it 'gets the fourth row of the pascal triangle' do
+    expect(pascal(4)).to eq([1, 3, 3, 1])
+  end
+
+  it 'gets the fifth row of the pascal triangle' do
+    expect(pascal(5)).to eq([1, 4, 6, 4, 1])
+  end
+
+  it 'gets the sixth row of the pascal triangle' do
+    expect(pascal(6)).to eq([1, 5, 10, 10, 5, 1])
+  end
+
+  it 'gets the seventh row of the pascal triangle' do
+    expect(pascal(7)).to eq([1, 6, 15, 20, 15, 6, 1])
+  end
+end

--- a/solutions/recursion/5_pascal/spec/spec_helper.rb
+++ b/solutions/recursion/5_pascal/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I'm working on adding Recursion Exercises to this repo because we determined it'd be beneficial to have this content in-house. See the linked issue for more information.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds an exercise, tests, and a solution for a method called `#pascal`. This method takes in a positive integer representing the row of Pascal's triangle that will be returned.
## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Related to #114 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Data types exercise: Update spec files`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes to exercises, they are also changed in the `solutions` folder.
