### PR TITLE
Add `permutations` exercise for recursion

### DIFF
--- a/recursion/4_permutations/.rspec
+++ b/recursion/4_permutations/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/recursion/4_permutations/exercises/permutation_exercises.rb
+++ b/recursion/4_permutations/exercises/permutation_exercises.rb
@@ -1,0 +1,16 @@
+def permutations(array)
+  # Write a method that takes in an array of integers and returns an array of
+  # all possible permutations of the original array. The permutations of a set
+  # are the different ways the elements can be arranged.
+  #
+  # For simplicity, the integers are guaranteed to not repeat.
+  #
+  # Examples:
+  # `permutations([1, 2, 3])` has six different permutations (or ways the elements can be arranged)
+  #  it should return `[[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]`
+  #
+  # `permutations([])` returns `[[]]`, as there's only one arrangement of an empty set
+  #
+  # NOTE: the tests do not check for ordering, so a return of `[[1, 2], [2, 1]]`
+  # will be treated the same as `[[2, 1], [1, 2]]`
+end

--- a/recursion/4_permutations/spec/permutation_exercises_spec.rb
+++ b/recursion/4_permutations/spec/permutation_exercises_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require_relative '../exercises/permutation_exercises'
+
+RSpec.describe '#permutations' do
+  it "returns 1 possible permutation for a set containing 0 numbers" do
+    expect(permutations([])).to eq [[]]
+  end
+
+  xit "returns 2 possible permutations for a set containing 2 numbers" do
+    expect(permutations([1, 2])).to match_array([[2, 1], [1, 2]])
+  end
+
+  xit "returns 6 possible permutations for a set containing 3 numbers" do
+    expected_set = [
+      [1, 2, 3], [1, 3, 2], [2, 1, 3],
+      [2, 3, 1], [3, 1, 2], [3, 2, 1]
+    ]
+
+    expect(permutations([1, 2, 3])).to match_array(expected_set)
+  end
+
+  xit "returns 24 possible permutations for a set containing 4 numbers" do
+    expected_set = [
+      [1, 2, 3, 4], [1, 2, 4, 3], [1, 3, 2, 4], [1, 3, 4, 2],
+      [1, 4, 2, 3], [1, 4, 3, 2], [2, 1, 3, 4], [2, 1, 4, 3],
+      [2, 3, 1, 4], [2, 3, 4, 1], [2, 4, 1, 3], [2, 4, 3, 1],
+      [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4], [3, 2, 4, 1],
+      [3, 4, 1, 2], [3, 4, 2, 1], [4, 1, 2, 3], [4, 1, 3, 2],
+      [4, 2, 1, 3], [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+    ]
+
+    expect(permutations([1, 2, 3, 4])).to match_array(expected_set)
+  end
+end

--- a/recursion/4_permutations/spec/spec_helper.rb
+++ b/recursion/4_permutations/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides

--- a/solutions/recursion/4_permutations/.rspec
+++ b/solutions/recursion/4_permutations/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper --format documentation --color

--- a/solutions/recursion/4_permutations/exercises/permutation_exercises.rb
+++ b/solutions/recursion/4_permutations/exercises/permutation_exercises.rb
@@ -1,0 +1,11 @@
+def permutations(array, index = 0, results = [])
+  results << array.dup if index == array.length
+
+  (index...array.length).each do |i|
+    array[index], array[i] = array[i], array[index]
+    permutations(array, index + 1, results)
+    array[index], array[i] = array[i], array[index]
+  end
+
+  results
+end

--- a/solutions/recursion/4_permutations/spec/permutations_spec.rb
+++ b/solutions/recursion/4_permutations/spec/permutations_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require_relative '../exercises/permutation_exercises'
+
+RSpec.describe '#permutations' do
+  it "returns 1 possible permutation for a set containing 0 numbers" do
+    expect(permutations([])).to eq [[]]
+  end
+
+  it "returns 2 possible permutations for a set containing 2 numbers" do
+    expect(permutations([1, 2])).to match_array([[2, 1], [1, 2]])
+  end
+
+  it "returns 6 possible permutations for a set containing 3 numbers" do
+    expected_set = [
+      [1, 2, 3], [1, 3, 2], [2, 1, 3],
+      [2, 3, 1], [3, 1, 2], [3, 2, 1]
+    ]
+
+    expect(permutations([1, 2, 3])).to match_array(expected_set)
+  end
+
+  it "returns 24 possible permutations for a set containing 4 numbers" do
+    expected_set = [
+      [1, 2, 3, 4], [1, 2, 4, 3], [1, 3, 2, 4], [1, 3, 4, 2],
+      [1, 4, 2, 3], [1, 4, 3, 2], [2, 1, 3, 4], [2, 1, 4, 3],
+      [2, 3, 1, 4], [2, 3, 4, 1], [2, 4, 1, 3], [2, 4, 3, 1],
+      [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4], [3, 2, 4, 1],
+      [3, 4, 1, 2], [3, 4, 2, 1], [4, 1, 2, 3], [4, 1, 3, 2],
+      [4, 2, 1, 3], [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+    ]
+
+    expect(permutations([1, 2, 3, 4])).to match_array(expected_set)
+  end
+end

--- a/solutions/recursion/4_permutations/spec/spec_helper.rb
+++ b/solutions/recursion/4_permutations/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+module FormatterOverrides
+  def dump_pending(_)
+  end
+end
+
+RSpec::Core::Formatters::DocumentationFormatter.prepend FormatterOverrides


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I'm working on adding Recursion Exercises to this repo because we determined it'd be beneficial to have this content in-house. See the linked issue for more information.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds an exercise, tests, and a solution for a `#permutations` method. This method takes an array of unique integers and returns a nested array containing all of its permutations.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Related to #114 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Data types exercise: Update spec files`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes changes to exercises, they are also changed in the `solutions` folder.
